### PR TITLE
Conserta a quebra de layout. 

### DIFF
--- a/app/assets/stylesheets/scss/_oer.scss
+++ b/app/assets/stylesheets/scss/_oer.scss
@@ -178,3 +178,28 @@
   @include size(339px, 200px);
   float: left;
 }
+
+.apps-list {
+  overflow: hidden;
+
+  .apps-list-item {
+    float: left;
+    position: relative;
+    $old-browser-value: 50%;
+    $expression: "(100% - 10px) / 2";
+    @include calc("width", $expression, $old-browser-value);
+    @include box-sizing;
+  }
+
+  .apps-list-item +
+  .apps-list-item { margin-left: 10px; }
+
+  hr {
+    @include background-clip(content-box);
+    padding: 10px 0;
+    margin: 0;
+    height: 1px;
+    border: none;
+    background-color: $gray3;
+  }
+}

--- a/app/assets/stylesheets/ui-components/_mixins.scss
+++ b/app/assets/stylesheets/ui-components/_mixins.scss
@@ -142,6 +142,14 @@
           box-sizing: $box-mode;
 }
 
+// Background clipping.
+//  $clip: o modelo.
+@mixin background-clip($clip) {
+  -webkit-background-clip: $clip;
+     -moz-background-clip: $clip;
+          background-clip: $clip;
+}
+
 // Opacidade.
 //  $opacity: o valor da opacidade (de 0 a 100).
 @mixin opacity($opacity: 100) {

--- a/app/helpers/apps_helper.rb
+++ b/app/helpers/apps_helper.rb
@@ -110,4 +110,9 @@ module AppsHelper
       end
     end
   end
+
+  # Mostra o separador somente a cada 2 iterações e quando não é o último.
+  def display_separator(index, total)
+    (index % 2 == 0) and (index != total)
+  end
 end

--- a/app/views/apps/index.html.erb
+++ b/app/views/apps/index.html.erb
@@ -56,10 +56,10 @@
   </div>
 
   <div class="oer-apps-wrapper">
-    <ul id="apps" class="list-2-columns list-columns-separator">
+    <div id="apps" class="apps-list">
       <%= render partial: 'shared/app', collection: @apps,
-                 locals: { favorite_flag: false } %>
-    </ul>
+                 locals: { favorite_flag: false, total: @apps.count } %>
+    </div>
   </div>
 
   <% if @apps.num_pages > 1 %>

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -26,9 +26,9 @@
     </div>
   <% end %>
   <div class="oer-apps-wrapper">
-    <ul id="apps" class="list-2-columns list-columns-separator">
+    <ul id="apps" class="apps-list">
       <%= render partial: 'shared/app', collection: @apps,
-                 locals: { favorite_flag: true } %>
+                 locals: { favorite_flag: true, total: @apps.count } %>
     </ul>
   </div>
 

--- a/app/views/shared/_app.html.erb
+++ b/app/views/shared/_app.html.erb
@@ -1,4 +1,4 @@
-<li class="general-list-item">
+<div class="apps-list-item general-list-item">
   <% if favorite_flag %>
     <%= link_to "Remover dos favoritos", user_favorite_path(current_user, App.favorited_by([app], current_user)),
                 :confirm => "Esta ação irá remover este aplicativo dos seus favoritos. Deseja continuar?", :method => :delete,
@@ -47,4 +47,7 @@
   <% if favorite_flag %>
     <button class="button-default" data-toggle="modal-app" data-modal-title="<%= app.name %>" data-modal-subtitle="<%= app.author %>" data-modal-url="<%= app.core_url %>">Abrir</button>
   <% end %>
-</li>
+</div>
+<% if display_separator(app_counter + 1, total) %>
+  <hr>
+<% end %>


### PR DESCRIPTION
A lista de aplicativos está [quebrando ](http://aplicativos.redu.com.br/aplicativos?utf8=%E2%9C%93&search=caminho) porque a maneira como a lista e separadores foi feita não funciona bem quando o primeiro elemento da linha é mais alto que o segundo.

Neste pull request tive que fazer os separadores com um `hr` mesmo, entre cada 2 itens da lista. Tive que trocar de `ul` e `li` por `div`s já que tive que incluir esse `hr`.

Closes #140.
